### PR TITLE
add cli variant - execute a fresh subprocess of libreoffice for each document

### DIFF
--- a/convert/app.py
+++ b/convert/app.py
@@ -3,15 +3,15 @@ import logging
 from flask import Flask, request, send_file
 from pantomime import FileName, normalize_mimetype, mimetype_extension
 
-from convert.converter import Converter, ConversionFailure, SystemFailure
-from convert.converter import CONVERT_DIR
+from convert.converter import ConversionFailure, SystemFailure, CONVERT_DIR, ConverterFactory
 from convert.formats import load_mime_extensions
 
+
+converter = ConverterFactory.get_instance(os.environ.get('CONVERTER_IMPLEMENTATION', 'unoconv'))
 PDF = "application/pdf"
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger("convert")
 extensions = load_mime_extensions()
-converter = Converter()
 app = Flask("convert")
 
 
@@ -20,8 +20,8 @@ app = Flask("convert")
 @app.route("/health/live")
 def check_health():
     try:
-        desktop = converter.connect()
-        if desktop is None:
+        setup_is_done = converter.setup_is_done
+        if not setup_is_done:
             return ("BUSY", 500)
         return ("OK", 200)
     except Exception:

--- a/convert/converter.py
+++ b/convert/converter.py
@@ -1,47 +1,14 @@
 import os
-import uno
-import time
 import shutil
+import importlib
 import logging
-import subprocess
-from threading import Timer
+from abc import ABC
 from tempfile import gettempdir
 from psutil import process_iter, pid_exists, TimeoutExpired
-from com.sun.star.beans import PropertyValue
-from com.sun.star.lang import DisposedException, IllegalArgumentException
-from com.sun.star.connection import NoConnectException
-from com.sun.star.io import IOException
-from com.sun.star.script import CannotConvertException
-from com.sun.star.uno import RuntimeException
 
-DESKTOP = "com.sun.star.frame.Desktop"
-RESOLVER = "com.sun.star.bridge.UnoUrlResolver"
-CONVERT_DIR = os.path.join(gettempdir(), "convert")
-OUT_FILE = os.path.join(CONVERT_DIR, "output.pdf")
+CONVERT_DIR = os.path.join(gettempdir(), 'convert')
 LOCK_FILE = os.path.join(gettempdir(), "convert.lock")
-INSTANCE_DIR = os.path.join(gettempdir(), "soffice")
-CONNECTION = (
-    "socket,host=localhost,port=2002,tcpNoDelay=1;urp;StarOffice.ComponentContext"
-)
-COMMAND = [
-    "/usr/bin/soffice",
-    "-env:UserInstallation=file:///%s" % INSTANCE_DIR,
-    "-env:JFW_PLUGIN_DO_NOT_CHECK_ACCESSIBILITY=1",
-    "--nologo",
-    "--headless",
-    "--nocrashreport",
-    # "--nodefault",
-    "--norestore",
-    "--accept=%s" % CONNECTION,
-]
-
 log = logging.getLogger(__name__)
-
-
-def flush_path(path):
-    if os.path.exists(path):
-        shutil.rmtree(path, ignore_errors=True)
-    os.makedirs(path, exist_ok=True)
 
 
 class ConversionFailure(Exception):
@@ -58,21 +25,14 @@ class SystemFailure(Exception):
     pass
 
 
+def flush_path(path):
+    if os.path.exists(path):
+        shutil.rmtree(path)
+    os.makedirs(path)
+
+
 class Converter(object):
-    """Launch a background instance of LibreOffice and convert documents
-    to PDF using it's filters.
-    """
-
-    PDF_FILTERS = (
-        ("com.sun.star.text.GenericTextDocument", "writer_pdf_Export"),
-        ("com.sun.star.text.WebDocument", "writer_web_pdf_Export"),
-        ("com.sun.star.presentation.PresentationDocument", "impress_pdf_Export"),
-        ("com.sun.star.drawing.DrawingDocument", "draw_pdf_Export"),
-    )
-
-    def __init__(self):
-        self.alive = False
-
+    """Generic libreoffice converter class."""
     def lock(self):
         # Race conditions galore, but how likely
         # are requests at that rate?
@@ -96,18 +56,30 @@ class Converter(object):
             return False
         return True
 
-    def get_soffice(self):
-        for proc in process_iter(["cmdline"]):
-            name = " ".join(proc.cmdline())
-            if "soffice.bin" in name:
-                return proc
+    def reset(self):
+        flush_path(CONVERT_DIR)
 
     def kill(self):
-        log.info("Disposing of LibreOffice.")
+        raise NotImplementedError()
+
+    @property
+    def setup_is_done(self):
+        raise NotImplementedError()
+
+    def convert_file(self, file_name, timeout):
+        raise NotImplementedError()
+
+
+class ProcessConverter(Converter, ABC):
+    def __init__(self, process_name):
+        self.process_name = process_name
+
+    def kill(self):
+        log.info("Disposing converter process.")
         # The Alfred Hitchcock approach to task management:
         # https://www.youtube.com/watch?v=0WtDmbr9xyY
         try:
-            proc = self.get_soffice()
+            proc = self.get_proc()
             if proc is not None:
                 proc.kill()
                 proc.wait(timeout=5)
@@ -117,130 +89,17 @@ class Converter(object):
             self.unlock()
             os._exit(23)
 
-    def reset(self):
-        flush_path(CONVERT_DIR)
+    def get_proc(self):
+        for proc in process_iter(["cmdline"]):
+            name = " ".join(proc.cmdline())
+            if self.process_name in name:
+                return proc
 
-    def start(self):
-        flush_path(INSTANCE_DIR)
-        log.info("Starting LibreOffice: %s", " ".join(COMMAND))
-        proc = subprocess.Popen(COMMAND, close_fds=True)
-        time.sleep(2)
-        log.info("PID: %s; return: %s", proc.pid, proc.returncode)
 
-    def _svc_create(self, ctx, clazz):
-        return ctx.ServiceManager.createInstanceWithContext(clazz, ctx)
-
-    def connect(self):
-        proc = self.get_soffice()
-        if proc is None:
-            self.start()
-
-        for attempt in range(15):
-            try:
-                context = uno.getComponentContext()
-                resolver = self._svc_create(context, RESOLVER)
-                context = resolver.resolve("uno:%s" % CONNECTION)
-                return self._svc_create(context, DESKTOP)
-            except NoConnectException:
-                log.warning("No connection to LibreOffice (%s)", attempt)
-                time.sleep(2)
-        raise SystemFailure("No connection to LibreOffice")
-
-    def check_health(self, desktop):
-        if desktop.getFrames().getCount() != 0:
-            raise SystemFailure("LibreOffice has stray frames.")
-        if desktop.getTasks() is not None:
-            raise SystemFailure("LibreOffice has stray tasks.")
-
-    def convert_file(self, file_name, timeout):
-        timer = Timer(timeout, self.kill)
-        timer.start()
-        try:
-            return self._timed_convert_file(file_name)
-        finally:
-            timer.cancel()
-
-    def _timed_convert_file(self, file_name):
-        desktop = self.connect()
-        self.check_health(desktop)
-        # log.debug("[%s] connected.", file_name)
-        try:
-            url = uno.systemPathToFileUrl(file_name)
-            props = self.property_tuple(
-                {
-                    "Hidden": True,
-                    "MacroExecutionMode": 0,
-                    "ReadOnly": True,
-                    "Overwrite": True,
-                    "OpenNewView": True,
-                    "StartPresentation": False,
-                    "RepairPackage": False,
-                }
-            )
-            doc = desktop.loadComponentFromURL(url, "_blank", 0, props)
-        except IllegalArgumentException:
-            raise ConversionFailure("Cannot open document.")
-        except DisposedException:
-            raise SystemFailure("Bridge is disposed.")
-
-        if doc is None:
-            raise ConversionFailure("Cannot open document.")
-
-        # log.debug("[%s] opened.", file_name)
-        try:
-            try:
-                doc.ShowChanges = False
-            except AttributeError:
-                pass
-
-            try:
-                doc.refresh()
-            except AttributeError:
-                pass
-
-            output_url = uno.systemPathToFileUrl(OUT_FILE)
-            prop = self.get_output_properties(doc)
-            # log.debug("[%s] refreshed.", file_name)
-            doc.storeToURL(output_url, prop)
-            # log.debug("[%s] exported.", file_name)
-            doc.dispose()
-            doc.close(True)
-            del doc
-            # log.debug("[%s] closed.", file_name)
-        except (
-            DisposedException,
-            IOException,
-            CannotConvertException,
-            RuntimeException,
-        ):
-            raise ConversionFailure("Cannot generate PDF.")
-
-        stat = os.stat(OUT_FILE)
-        if stat.st_size == 0 or not os.path.exists(OUT_FILE):
-            raise ConversionFailure("Cannot generate PDF.")
-        return OUT_FILE
-
-    def get_output_properties(self, doc):
-        # https://github.com/unoconv/unoconv/blob/master/doc/filters.adoc
-        filter_name = "writer_pdf_Export"
-        for (service, pdf) in self.PDF_FILTERS:
-            if doc.supportsService(service):
-                filter_name = pdf
-        return self.property_tuple(
-            {
-                "FilterName": filter_name,
-                "Overwrite": True,
-                "ReduceImageResolution": True,
-                "MaxImageResolution": 300,
-                "SelectPdfVersion": 1,
-            }
-        )
-
-    def property_tuple(self, propDict):
-        properties = []
-        for k, v in propDict.items():
-            prop = PropertyValue()
-            prop.Name = k
-            prop.Value = v
-            properties.append(prop)
-        return tuple(properties)
+class ConverterFactory(object):
+    @staticmethod
+    def get_instance(implementation):
+        print("loading " + implementation + " implementation")
+        module = importlib.import_module("." + implementation, 'convert.converters')
+        cls = getattr(module, implementation.capitalize() + 'Converter')
+        return cls()

--- a/convert/converters/cli.py
+++ b/convert/converters/cli.py
@@ -1,0 +1,57 @@
+import os
+import logging
+import subprocess
+from tempfile import gettempdir
+from convert.converter import CONVERT_DIR, flush_path, ProcessConverter, ConversionFailure
+
+OUT_DIR = os.path.join(CONVERT_DIR, '/tmp/out/')
+OUT_FILE = os.path.join(CONVERT_DIR, 'output.pdf')
+INSTANCE_DIR = os.path.join(gettempdir(), 'soffice')
+ENV = '"-env:UserInstallation=file:///%s"' % INSTANCE_DIR
+COMMAND = ['/usr/bin/libreoffice', ENV, '--nologo', '--headless', '--nocrashreport', '--nodefault', '--norestore',
+           '--nolockcheck', '--invisible', '--convert-to', 'pdf', '--outdir', OUT_DIR]  # noqa
+
+log = logging.getLogger(__name__)
+
+
+class CliConverter(ProcessConverter):
+    @property
+    def setup_is_done(self):
+        return True
+
+    def __init__(self):
+        super().__init__("libreoffice")
+
+    def on_convert_error(self, e):
+        self.kill()
+        raise ConversionFailure('Cannot generate PDF.', e)
+
+    def convert_file(self, file_name, timeout):
+        flush_path(INSTANCE_DIR)
+        flush_path(OUT_DIR)
+        self.kill()
+        cmd = COMMAND.copy()
+        cmd.append(file_name)
+
+        out_file = None
+        try:
+            log.info('Starting LibreOffice: %s with timeout %s', cmd, timeout)
+            subprocess.run(cmd, timeout=timeout)
+
+            files = os.listdir(OUT_DIR)
+            pdf_files = list(filter(lambda f: f.endswith('.pdf'), files))
+            if len(pdf_files) <= 0:
+                raise ConversionFailure('Cannot generate PDF.')
+
+            out_file = os.path.join(OUT_DIR, pdf_files[0])
+        except Exception as e:
+            log.info("LibreOffice conversion failed", e)
+            self.on_convert_error(e)
+
+        if out_file is None:
+            raise ConversionFailure('Cannot generate PDF.')
+
+        stat = os.stat(out_file)
+        if stat.st_size == 0 or not os.path.exists(out_file):
+            raise ConversionFailure('Cannot generate PDF.')
+        return out_file

--- a/convert/converters/unoconv.py
+++ b/convert/converters/unoconv.py
@@ -1,0 +1,183 @@
+import os
+import uno
+import time
+import logging
+import subprocess
+from threading import Timer
+from tempfile import gettempdir
+from convert.converter import CONVERT_DIR, flush_path, ProcessConverter, SystemFailure, ConversionFailure
+from com.sun.star.beans import PropertyValue
+from com.sun.star.lang import DisposedException, IllegalArgumentException
+from com.sun.star.connection import NoConnectException
+from com.sun.star.io import IOException
+from com.sun.star.script import CannotConvertException
+from com.sun.star.uno import RuntimeException
+
+DESKTOP = "com.sun.star.frame.Desktop"
+RESOLVER = "com.sun.star.bridge.UnoUrlResolver"
+OUT_FILE = os.path.join(CONVERT_DIR, "output.pdf")
+LOCK_FILE = os.path.join(gettempdir(), "convert.lock")
+INSTANCE_DIR = os.path.join(gettempdir(), "soffice")
+CONNECTION = (
+    "socket,host=localhost,port=2002,tcpNoDelay=1;urp;StarOffice.ComponentContext"
+)
+COMMAND = [
+    "/usr/bin/soffice",
+    "-env:UserInstallation=file:///%s" % INSTANCE_DIR,
+    "-env:JFW_PLUGIN_DO_NOT_CHECK_ACCESSIBILITY=1",
+    "--nologo",
+    "--headless",
+    "--nocrashreport",
+    # "--nodefault",
+    "--norestore",
+    "--accept=%s" % CONNECTION,
+]
+
+log = logging.getLogger(__name__)
+
+
+class UnoconvConverter(ProcessConverter):
+    """Launch a background instance of LibreOffice and convert documents
+    to PDF using it's filters.
+    """
+
+    PDF_FILTERS = (
+        ("com.sun.star.text.GenericTextDocument", "writer_pdf_Export"),
+        ("com.sun.star.text.WebDocument", "writer_web_pdf_Export"),
+        ("com.sun.star.presentation.PresentationDocument", "impress_pdf_Export"),
+        ("com.sun.star.drawing.DrawingDocument", "draw_pdf_Export"),
+    )
+
+    def __init__(self):
+        super().__init__("soffice.bin")
+        self.alive = False
+
+    def start(self):
+        flush_path(INSTANCE_DIR)
+        log.info("Starting LibreOffice: %s", " ".join(COMMAND))
+        proc = subprocess.Popen(COMMAND, close_fds=True)
+        time.sleep(2)
+        log.info("PID: %s; return: %s", proc.pid, proc.returncode)
+
+    def _svc_create(self, ctx, clazz):
+        return ctx.ServiceManager.createInstanceWithContext(clazz, ctx)
+
+    def connect(self):
+        proc = self.get_proc()
+        if proc is None:
+            self.start()
+
+        for attempt in range(15):
+            try:
+                context = uno.getComponentContext()
+                resolver = self._svc_create(context, RESOLVER)
+                context = resolver.resolve("uno:%s" % CONNECTION)
+                return self._svc_create(context, DESKTOP)
+            except NoConnectException:
+                log.warning("No connection to LibreOffice (%s)", attempt)
+                time.sleep(2)
+        raise SystemFailure("No connection to LibreOffice")
+
+    @property
+    def setup_is_done(self):
+        desktop = self.connect()
+        return desktop is not None
+
+    def check_health(self, desktop):
+        if desktop.getFrames().getCount() != 0:
+            raise SystemFailure("LibreOffice has stray frames.")
+        if desktop.getTasks() is not None:
+            raise SystemFailure("LibreOffice has stray tasks.")
+
+    def convert_file(self, file_name, timeout):
+        timer = Timer(timeout, self.kill)
+        timer.start()
+        try:
+            return self._timed_convert_file(file_name)
+        finally:
+            timer.cancel()
+
+    def _timed_convert_file(self, file_name):
+        desktop = self.connect()
+        self.check_health(desktop)
+        # log.debug("[%s] connected.", file_name)
+        try:
+            url = uno.systemPathToFileUrl(file_name)
+            props = self.property_tuple(
+                {
+                    "Hidden": True,
+                    "MacroExecutionMode": 0,
+                    "ReadOnly": True,
+                    "Overwrite": True,
+                    "OpenNewView": True,
+                    "StartPresentation": False,
+                    "RepairPackage": False,
+                }
+            )
+            doc = desktop.loadComponentFromURL(url, "_blank", 0, props)
+        except IllegalArgumentException:
+            raise ConversionFailure("Cannot open document.")
+        except DisposedException:
+            raise SystemFailure("Bridge is disposed.")
+
+        if doc is None:
+            raise ConversionFailure("Cannot open document.")
+
+        # log.debug("[%s] opened.", file_name)
+        try:
+            try:
+                doc.ShowChanges = False
+            except AttributeError:
+                pass
+
+            try:
+                doc.refresh()
+            except AttributeError:
+                pass
+
+            output_url = uno.systemPathToFileUrl(OUT_FILE)
+            prop = self.get_output_properties(doc)
+            # log.debug("[%s] refreshed.", file_name)
+            doc.storeToURL(output_url, prop)
+            # log.debug("[%s] exported.", file_name)
+            doc.dispose()
+            doc.close(True)
+            del doc
+            # log.debug("[%s] closed.", file_name)
+        except (
+            DisposedException,
+            IOException,
+            CannotConvertException,
+            RuntimeException,
+        ):
+            raise ConversionFailure("Cannot generate PDF.")
+
+        stat = os.stat(OUT_FILE)
+        if stat.st_size == 0 or not os.path.exists(OUT_FILE):
+            raise ConversionFailure("Cannot generate PDF.")
+        return OUT_FILE
+
+    def get_output_properties(self, doc):
+        # https://github.com/unoconv/unoconv/blob/master/doc/filters.adoc
+        filter_name = "writer_pdf_Export"
+        for (service, pdf) in self.PDF_FILTERS:
+            if doc.supportsService(service):
+                filter_name = pdf
+        return self.property_tuple(
+            {
+                "FilterName": filter_name,
+                "Overwrite": True,
+                "ReduceImageResolution": True,
+                "MaxImageResolution": 300,
+                "SelectPdfVersion": 1,
+            }
+        )
+
+    def property_tuple(self, propDict):
+        properties = []
+        for k, v in propDict.items():
+            prop = PropertyValue()
+            prop.Name = k
+            prop.Value = v
+            properties.append(prop)
+        return tuple(properties)


### PR DESCRIPTION
in contrast to the existing unoconv variant, no background listener is used. Improves reliability, reduces performance for single-page / small documents

The implementation can be switched by setting the environment variable `CONVERTER_IMPLEMENTATION` to `cli` - default is `unoconv`.

As both variants can only handle one document at a time, both need a lockfile. I extracted the handling of the lockfile to the `Converter` superclass. This class would in theory be suitable for other single-threaded converters which don't use libreoffice at all, as well as the ConverterFactory logic.
Aside from that, I tried to don't touch the existing unoconv converter code